### PR TITLE
bug fix: command should be one space-split string to be used with shell=True

### DIFF
--- a/nico_tools/nicovideo_dl.py
+++ b/nico_tools/nicovideo_dl.py
@@ -158,7 +158,7 @@ class DownloadVideo(NicoWalker):
     def download(session, watch_id, save_directory, overwrite=False, convert_mp3=False, mp3_bitrate="192"):
         if convert_mp3:
             try:
-                subprocess.run(["ffmpeg", "-version"], shell=True, check=True, stdout=subprocess.DEVNULL)
+                subprocess.run(["ffmpeg -version"], shell=True, check=True, stdout=subprocess.DEVNULL)
             except subprocess.CalledProcessError:
                 print("ffmpegが実行できません。ffmpegがインストールされ、PATHに含まれているか確認してください。\n"
                       "インストールする場合、 https://www.ffmpeg.org/download.html を参照してください。")


### PR DESCRIPTION
mp3変換機能を使おうと思った際に、
ffmpegのバージョンチェックでエラーが出ました。

subprocess.runをshell=Trueで使うときには、コマンド文字列を分けないので修正しました。
145行目では分かれてないので、多分修正し忘れだと思います。

ただ、OSX上でのエラーですので、WindowsやLinux上では問題ないかもしれません。
もともとサポート対象外ですので、必要なければ却下してください。

よろですー。