### PR TITLE
Mac ChromeDriver

### DIFF
--- a/nico_tools/web_drivers.json
+++ b/nico_tools/web_drivers.json
@@ -59,6 +59,12 @@
         "download_url": "https://chromedriver.storage.googleapis.com/2.39/chromedriver_linux64.zip",
         "path": "/download/ChromeDriver/chromedriver"
       }
+    },
+    "Darwin": {
+      "64bit": {
+        "download_url": "https://chromedriver.storage.googleapis.com/2.40/chromedriver_mac64.zip",
+        "path": "/download/ChromeDriver/chromedriver"
+      }
     }
   }
 }

--- a/nico_tools/web_drivers.py
+++ b/nico_tools/web_drivers.py
@@ -122,7 +122,7 @@ class ChromeDriver(WebDriver):
 
     def extract(self):
         self.extract_zip()
-        if self.system == "Linux":
+        if self.system in {"Linux", "Darwin"}:
             os.chmod(self.execute_path, stat.S_IRWXU)
 
     def generate_driver(self):


### PR DESCRIPTION
Mac上でも、ChromeDriverが動作することを確認できましたので、
PR出しておきます。

Macはサポート外とのことでしたので、不要でしたら
却下してくださいー。

よろですー！